### PR TITLE
Fix half-visible language toggle button

### DIFF
--- a/public/assets/css/animations.css
+++ b/public/assets/css/animations.css
@@ -142,7 +142,6 @@
 /* Анимация переключателя языка */
 .language-switch {
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    position: relative;
     overflow: hidden;
 }
 


### PR DESCRIPTION
Remove `position: relative` from `.language-switch` to fix the half-visible language switch button.

The `position: relative` in `animations.css` was overriding the intended `position: fixed` from `language-switch.css`, causing the button to be clipped. Removing the conflicting style ensures the button is fully visible and correctly pinned to the top-right.

---
<a href="https://cursor.com/background-agent?bcId=bc-e268f292-d82f-4b30-a40e-282f6ef5d6b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e268f292-d82f-4b30-a40e-282f6ef5d6b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

